### PR TITLE
Escape the `userName` passed from the request event

### DIFF
--- a/src/service/ldapUserStoreService.ts
+++ b/src/service/ldapUserStoreService.ts
@@ -1,4 +1,4 @@
-import { Client, Entry } from 'ldapts';
+import { Client, Entry, RDN } from 'ldapts';
 import { InvalidCredentialsError, NoSuchObjectError } from 'ldapts/errors/resultCodeErrors';
 import { SecretsManager } from '@dvsa/secrets-manager';
 import { Logger } from '../util/logger';
@@ -17,7 +17,11 @@ export class LdapUserStoreService {
   public async getUser(userName: string): Promise<Entry | null> {
     const client = this.createClient();
 
-    const searchDn = `${process.env.LDAP_USERNAME_ATTRIBUTE}=${userName},${process.env.LDAP_USER_SEARCH_BASE}`;
+    const usernameDn: RDN = new RDN({
+      [process.env.LDAP_USERNAME_ATTRIBUTE]: userName,
+    });
+
+    const searchDn = `${usernameDn.toString()},${process.env.LDAP_USER_SEARCH_BASE}`;
 
     try {
       const ldapAdminPassword: string = await this.getLdapAdminPassword();


### PR DESCRIPTION
## Description

The username from the request is used to build a `dn`, this PR will escape the user-input to prevent LDAP injections (https://cheatsheetseries.owasp.org/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.html).

The `RDN` object has an escape function that follows the recommended escaping spec when calling `toString()`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works