### PR TITLE
VOL-3104: Remove assigning username alias attribute by default in userAttributes

### DIFF
--- a/src/handler/cognitoUserMigrationEvent.ts
+++ b/src/handler/cognitoUserMigrationEvent.ts
@@ -13,8 +13,6 @@ export const generateMigrationEventResponse = (
   const map: Record<string, string> = JSON.parse(process.env.LDAP_OBJECT_FILTER_MAP) as Record<string, string>;
   const attributes: Record<string, string> = {};
 
-  attributes.username = event.userName;
-
   for (let i = 0; i < Object.keys(user).length; i++) {
     const key: string = Object.keys(user)[Number(i)];
     if (key in map) {

--- a/tests/handler/cognitoUserMigrationEvent.test.ts
+++ b/tests/handler/cognitoUserMigrationEvent.test.ts
@@ -160,24 +160,5 @@ describe('Test cognitoUserMigrationEventHandler', () => {
       expect(result.response).toHaveProperty('messageAction');
       expect(result.response.messageAction).toBe('SUPPRESS');
     });
-    test('Username defaults to requested username if not mapped in env', () => {
-      const eventMock: UserMigrationAuthenticationTriggerEvent = <UserMigrationAuthenticationTriggerEvent> {
-        triggerSource: 'UserMigration_Authentication',
-        userName: 'cAse0001',
-        response: {
-          userAttributes: {},
-        },
-      };
-
-      const entry: Entry = <Entry> {
-        dn: 'dn-test',
-        cn: 'CASE0001',
-      };
-
-      const result: UserMigrationTriggerEvent = handler.generateMigrationEventResponse(entry, eventMock);
-
-      expect(result.response.userAttributes).toHaveProperty('username');
-      expect(result.response.userAttributes.username).toEqual(eventMock.userName);
-    });
   });
 });


### PR DESCRIPTION
## Description

This changes reverts the functionality to set the username attribute on userAttributes by default; as it is not needed and is intended to create username aliases, not the resulting username used for Cognito.

Related issue: https://dvsa.atlassian.net/browse/VOL-3104

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works