### PR TITLE
feat: Remove npm version from test GH action, node 18 defaults to 9.x

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,8 +10,6 @@ jobs:
         with:
           node-version: '18'
           cache: 'npm'
-      - name: Bump NPM to v9
-        run: npm i -g npm@9
       - name: Install dependencies
         run: npm ci
       - name: Run lint


### PR DESCRIPTION
## Description

Remove npm version from test GH action, as node 18 defaults to npm 9.x.

Related issue: [N/A](N/A)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works